### PR TITLE
Update HUDAmmoDisplay.uc

### DIFF
--- a/_Classes/DeusEx/Classes/HUDAmmoDisplay.uc
+++ b/_Classes/DeusEx/Classes/HUDAmmoDisplay.uc
@@ -136,7 +136,7 @@ event DrawWindow(GC gc)
 			}
 			else
 			{
-				if (weapon.IsInState('Reload'))
+				if (weapon.IsInState('Reload') || weapon.bPerShellReload == false)
 					gc.DrawText(infoX, 26, 20, 9, msgReloading);
 				else
 					gc.DrawText(infoX, 26, 20, 9, ammoRemaining);

--- a/_Classes/DeusEx/Classes/HUDAmmoDisplay.uc
+++ b/_Classes/DeusEx/Classes/HUDAmmoDisplay.uc
@@ -136,7 +136,7 @@ event DrawWindow(GC gc)
 			}
 			else
 			{
-				if (weapon.IsInState('Reload') || weapon.bPerShellReload == false)
+				if (weapon.IsInState('Reload') && weapon.bPerShellReload == false)
 					gc.DrawText(infoX, 26, 20, 9, msgReloading);
 				else
 					gc.DrawText(infoX, 26, 20, 9, ammoRemaining);


### PR DESCRIPTION
Weapons that reload per shell don't get the -- message so you can see how much ammo is in the gun while it's reloading