### PR TITLE
Melee Priority

### DIFF
--- a/Docs/List of Changes.md
+++ b/Docs/List of Changes.md
@@ -30,7 +30,10 @@ Sarge's Changes since Beta 2.2:
     - The Nano Keyring now tells you which key was used when locking/unlocking a door.
     - Complete overhaul of "Left-click frobbing", which happens when left-clicking certain items without an item equipped.
         - Left-Clicking a datacube will pick it up and allow you to carry it.
-        - Left-Clicking a breakable box, window or wall will select your last used melee weapon (except melee weapons assigned as a quick secondary)
+        - Left-Clicking a breakable box, window or wall will select a melee weapon from your inventory based on a priority list.
+            - The priority list is as follows: Chinese Sword, Crowbar, Combat Knife, Baton, Dragon Tooth Sword.
+            - If you don't have the weapon or the weapon deals less damage than the breakable object's DT, it'll go to the next one in the priority list.
+            - The DT check is disabled on hardcore, so it simply checks the weapon's priority and equips it even if it won't deal enough damage to break the container.
         - Left-Clicking on a door will pull out the Nano Keyring if you have the correct key, otherwise it will pull out a lockpick.
             - This behaviour is disabled in Hardcore mode
             - In Hardcore, Left-Clicking on a door will always pull out a lockpick (or the keyring if the lock is unpickable or you have no lockpicks). Right-clicking will then swap between the keyring and lockpicks.

--- a/_Classes/DeusEx/Classes/BreakableGlass.uc
+++ b/_Classes/DeusEx/Classes/BreakableGlass.uc
@@ -9,7 +9,7 @@ var() bool ParisUndergroundHack;
 //Simply pull out a melee weapon
 function bool DoLeftFrob(DeusExPlayer frobber)
 {
-    frobber.GetMeleePriority();
+    frobber.GetMeleePriority(minDamageThreshold);
     return false;
 }
 

--- a/_Classes/DeusEx/Classes/BreakableGlass.uc
+++ b/_Classes/DeusEx/Classes/BreakableGlass.uc
@@ -9,7 +9,7 @@ var() bool ParisUndergroundHack;
 //Simply pull out a melee weapon
 function bool DoLeftFrob(DeusExPlayer frobber)
 {
-    frobber.GetMeleePriority(minDamageThreshold);
+    frobber.SelectMeleePriority(minDamageThreshold);
     return false;
 }
 

--- a/_Classes/DeusEx/Classes/BreakableGlass.uc
+++ b/_Classes/DeusEx/Classes/BreakableGlass.uc
@@ -9,7 +9,7 @@ var() bool ParisUndergroundHack;
 //Simply pull out a melee weapon
 function bool DoLeftFrob(DeusExPlayer frobber)
 {
-    frobber.PutInHand(frobber.lastMeleeWeapon);
+    frobber.GetMeleePriority();
     return false;
 }
 

--- a/_Classes/DeusEx/Classes/BreakableWall.uc
+++ b/_Classes/DeusEx/Classes/BreakableWall.uc
@@ -7,7 +7,7 @@ class BreakableWall expands DeusExMover;
 //Simply pull out a melee weapon
 function bool DoLeftFrob(DeusExPlayer frobber)
 {
-    frobber.GetMeleePriority(minDamageThreshold);
+    frobber.SelectMeleePriority(minDamageThreshold);
     return false;
 }
 

--- a/_Classes/DeusEx/Classes/BreakableWall.uc
+++ b/_Classes/DeusEx/Classes/BreakableWall.uc
@@ -7,7 +7,7 @@ class BreakableWall expands DeusExMover;
 //Simply pull out a melee weapon
 function bool DoLeftFrob(DeusExPlayer frobber)
 {
-    frobber.GetMeleePriority();
+    frobber.GetMeleePriority(minDamageThreshold);
     return false;
 }
 

--- a/_Classes/DeusEx/Classes/BreakableWall.uc
+++ b/_Classes/DeusEx/Classes/BreakableWall.uc
@@ -7,7 +7,7 @@ class BreakableWall expands DeusExMover;
 //Simply pull out a melee weapon
 function bool DoLeftFrob(DeusExPlayer frobber)
 {
-    frobber.PutInHand(frobber.lastMeleeWeapon);
+    frobber.GetMeleePriority();
     return false;
 }
 

--- a/_Classes/DeusEx/Classes/Containers.uc
+++ b/_Classes/DeusEx/Classes/Containers.uc
@@ -12,7 +12,7 @@ var   bool bSelectMeleeWeapon; //Select a melee weapon when we left-frob this co
 
 function bool DoLeftFrob(DeusExPlayer frobber)
 {
-    frobber.GetMeleePriority();
+    frobber.GetMeleePriority(minDamageThreshold);
     return false;
 }
 

--- a/_Classes/DeusEx/Classes/Containers.uc
+++ b/_Classes/DeusEx/Classes/Containers.uc
@@ -12,13 +12,8 @@ var   bool bSelectMeleeWeapon; //Select a melee weapon when we left-frob this co
 
 function bool DoLeftFrob(DeusExPlayer frobber)
 {
-    if (bSelectMeleeWeapon)
-    {
-        frobber.PutInHand(frobber.lastMeleeWeapon);
-        return false;
-    }
-    else
-        return true;
+    frobber.GetMeleePriority();
+    return false;
 }
 
 //

--- a/_Classes/DeusEx/Classes/Containers.uc
+++ b/_Classes/DeusEx/Classes/Containers.uc
@@ -12,7 +12,7 @@ var   bool bSelectMeleeWeapon; //Select a melee weapon when we left-frob this co
 
 function bool DoLeftFrob(DeusExPlayer frobber)
 {
-    frobber.GetMeleePriority(minDamageThreshold);
+    frobber.SelectMeleePriority(minDamageThreshold);
     return false;
 }
 

--- a/_Classes/DeusEx/Classes/DeusExMover.uc
+++ b/_Classes/DeusEx/Classes/DeusExMover.uc
@@ -89,6 +89,11 @@ function bool DoLeftFrob(DeusExPlayer frobber)
     {
         if (!bPickable || !frobber.SelectInventoryItem('Lockpick'))
             frobber.PutInHand(frobber.KeyRing);
+			
+		if (bBreakable)
+		{
+			frobber.GetMeleePriority(minDamageThreshold);
+		}
         return false;
     }
     else if (CanToggleLock(frobber,frobber.KeyRing))

--- a/_Classes/DeusEx/Classes/DeusExMover.uc
+++ b/_Classes/DeusEx/Classes/DeusExMover.uc
@@ -92,7 +92,7 @@ function bool DoLeftFrob(DeusExPlayer frobber)
 			
 		if (bBreakable)
 		{
-			frobber.GetMeleePriority(minDamageThreshold);
+			frobber.SelectMeleePriority(minDamageThreshold);
 		}
         return false;
     }

--- a/_Classes/DeusEx/Classes/DeusExPlayer.uc
+++ b/_Classes/DeusEx/Classes/DeusExPlayer.uc
@@ -557,8 +557,6 @@ const DRUG_CRACK = 2;
 
 var bool autosave;                                                              //Sarge: Autosave tells the Quicksave function to make an autosave instead
 
-var travel DeusExWeapon lastMeleeWeapon;                                           //Sarge: Stores our last melee weapon, for use when left-click frobbing crates and other breakables
-
 //////////END GMDX
 
 // native Functions
@@ -2397,6 +2395,46 @@ function RecoilEffectTick(float deltaTime)
               RecoilShake=vect(0,0,0);
 		}
 	}
+}
+
+// ----------------------------------------------------------------------
+// GetMeleePriority()
+// ----------------------------------------------------------------------
+
+function GetMeleePriority() // Trash: Used to automatically decide what to draw, does NOT take into account container minimum damage!
+{
+	local Inventory anItem;
+	local DeusExWeapon meleeWeapon;
+
+	local DeusExWeapon crowbar, sword, knife, baton, dts;
+
+	For(anItem = Inventory; anItem != None; anItem = anItem.Inventory) // Go through the entire inventory, check for these melee weapons
+	{
+		if (anItem.IsA('WeaponCrowbar'))
+			crowbar = DeusExWeapon(anItem);
+		if (anItem.IsA('WeaponSword'))
+			sword = DeusExWeapon(anItem);
+		if (anItem.IsA('WeaponCombatKnife'))
+			knife = DeusExWeapon(anItem);
+		if (anItem.IsA('WeaponBaton'))
+			baton = DeusExWeapon(anItem);
+		if (anItem.IsA('WeaponNanoSword'))
+			dts = DeusExWeapon(anItem);
+	}
+
+	if (crowbar != none) // Prioritize weapons better at breaking containers, DTS is an exception because it generates sound when equipped
+		meleeWeapon = crowbar;
+	else if (sword != none)
+		meleeWeapon = sword;
+	else if (knife != none)
+		meleeWeapon = knife;
+	else if (baton != none)
+		meleeWeapon = baton;
+	else if (dts != none)
+		meleeWeapon = dts;
+	
+
+	PutInHand(meleeWeapon);
 }
 
 // ----------------------------------------------------------------------

--- a/_Classes/DeusEx/Classes/DeusExPlayer.uc
+++ b/_Classes/DeusEx/Classes/DeusExPlayer.uc
@@ -279,6 +279,7 @@ var localized String NoRoomToLift;
 var localized String CanCarryOnlyOne;
 var localized String CannotDropHere;
 var localized String HandsFull;
+var localized String CantBreakDT;
 var localized String NoteAdded;
 var localized String GoalAdded;
 var localized String PrimaryGoalCompleted;
@@ -2398,10 +2399,10 @@ function RecoilEffectTick(float deltaTime)
 }
 
 // ----------------------------------------------------------------------
-// GetMeleePriority()
+// SelectMeleePriority()
 // ----------------------------------------------------------------------
 
-function GetMeleePriority(int damageThreshold)	// Trash: Used to automatically decide what to draw
+function SelectMeleePriority(int damageThreshold)	// Trash: Used to automatically decide what to draw
 {
 	local Inventory anItem;
 	local DeusExWeapon meleeWeapon;
@@ -2422,33 +2423,24 @@ function GetMeleePriority(int damageThreshold)	// Trash: Used to automatically d
 			dts = DeusExWeapon(anItem);
 	}
 
+	if (sword == None && crowbar == none && knife == none && baton == none && dts == none)	// Don't proceed if you have no melee weapons
+	{
+		return;
+	}
 
-	if (bHardcoreMode)
-	{
-		if (sword != none)	// Prioritize weapons better at breaking containers
-			meleeWeapon = sword;
-		else if (crowbar != none)
-			meleeWeapon = crowbar;
-		else if (knife != none)
-			meleeWeapon = knife;
-		else if (baton != none)
-			meleeWeapon = baton;
-		else if (dts != none)
-			meleeWeapon = dts;
-	}
-	else
-	{
-		if (sword != none && BreaksDamageThreshold(sword, damageThreshold))	// Prioritize weapons based on priority and container DT
-			meleeWeapon = sword;
-		else if (crowbar != none && BreaksDamageThreshold(crowbar, damageThreshold))
-			meleeWeapon = crowbar;
-		else if (knife != none && BreaksDamageThreshold(knife, damageThreshold))
-			meleeWeapon = knife;
-		else if (baton != none && BreaksDamageThreshold(baton, damageThreshold))
-			meleeWeapon = baton;
-		else if (dts != none && BreaksDamageThreshold(dts, damageThreshold))
-			meleeWeapon = dts;
-	}
+
+	if (sword != None && (bHardCoreMode || BreaksDamageThreshold(sword, damageThreshold)))
+		meleeWeapon = sword;
+	else if (crowbar != None && (bHardCoreMode || BreaksDamageThreshold(crowbar, damageThreshold)))
+		meleeWeapon = crowbar;
+	else if (knife != None && (bHardCoreMode || BreaksDamageThreshold(knife, damageThreshold)))
+		meleeWeapon = knife;
+	else if (baton != None && (bHardCoreMode || BreaksDamageThreshold(baton, damageThreshold)))
+		meleeWeapon = baton;
+	else if (dts != None && (bHardCoreMode || BreaksDamageThreshold(dts, damageThreshold)))
+		meleeWeapon = dts;
+	else if (!bHardCoreMode)
+		ClientMessage(CantBreakDT);
 	
 	if (meleeWeapon != None)
 		PutInHand(meleeWeapon);
@@ -2461,14 +2453,7 @@ function bool BreaksDamageThreshold(DeusExWeapon weapon, int damageThreshold)	//
 	if (weapon.IsA('WeaponCrowbar'))	// Special check for Crowbar since it deals +5 extra damage to objects
 		mod += 5;
 
-	if ((weapon.CalculateTrueDamage() + mod) >= damageThreshold)
-	{
-		return true;
-	}
-	else
-	{
-		return false;
-	}
+	return (weapon.CalculateTrueDamage() + mod) >= damageThreshold;
 }
 
 // ----------------------------------------------------------------------
@@ -17032,6 +17017,7 @@ defaultproperties
      CanCarryOnlyOne="You can only carry one %s"
      CannotDropHere="Can't drop that here"
      HandsFull="Your hands are full"
+	 CantBreakDT="Strongest melee damage doesn't pass threshold"
      NoteAdded="Note Received - Check DataVault For Details"
      GoalAdded="Goal Received - Check DataVault For Details"
      PrimaryGoalCompleted="Primary Goal Completed"

--- a/_Classes/DeusEx/Classes/DeusExWeapon.uc
+++ b/_Classes/DeusEx/Classes/DeusExWeapon.uc
@@ -337,12 +337,13 @@ function bool DoRightFrob(DeusExPlayer frobber, bool objectInHand)
     return true;
 }
 
+// Trash: Sarge, is this thing obsolete now?
+
 //Called when the item is added to the players hands
 function Draw(DeusExPlayer frobber)
 {
-    if (bIsMeleeWeapon && frobber.assignedWeapon != Self)
-        frobber.lastMeleeWeapon = self;
-
+    //if (bIsMeleeWeapon && frobber.assignedWeapon != Self)
+    //    frobber.lastMeleeWeapon = self;
 }
 
 // ---------------------------------------------------------------------
@@ -1371,6 +1372,15 @@ simulated function float GetWeaponSkill()
 		}
 	}
 	return value;
+}
+
+function int CalculateTrueDamage()
+{
+	local int trueDamage;
+
+	trueDamage = HitDamage * (1.0 - (2.0 * GetWeaponSkill()) + ModDamage);
+
+	return trueDamage;
 }
 
 // calculate the accuracy for this weapon and the owner's damage

--- a/_Classes/DeusEx/Classes/DeusExWeapon.uc
+++ b/_Classes/DeusEx/Classes/DeusExWeapon.uc
@@ -299,7 +299,6 @@ var localized string abridgedName;                                              
 var texture largeIconRot;                                                       //RSD: rotated inventory icon
 var travel int invSlotsXtravel;                                                 //RSD: since Inventory invSlotsX doesn't travel through maps
 var travel int invSlotsYtravel;                                                 //RSD: since Inventory invSlotsY doesn't travel through maps
-var bool bIsMeleeWeapon;                                                        //Is this weapon a melee weapon? Used for selecting our last melee weapon for crate-breaking
 //END GMDX:
 
 //
@@ -337,13 +336,11 @@ function bool DoRightFrob(DeusExPlayer frobber, bool objectInHand)
     return true;
 }
 
-// Trash: Sarge, is this thing obsolete now?
 
 //Called when the item is added to the players hands
 function Draw(DeusExPlayer frobber)
 {
-    //if (bIsMeleeWeapon && frobber.assignedWeapon != Self)
-    //    frobber.lastMeleeWeapon = self;
+
 }
 
 // ---------------------------------------------------------------------

--- a/_Classes/DeusEx/Classes/WeaponBaton.uc
+++ b/_Classes/DeusEx/Classes/WeaponBaton.uc
@@ -56,7 +56,6 @@ function name WeaponDamageType()
 
 defaultproperties
 {
-     //bIsMeleeWeapon = true //SARGE: Not really a good melee weapon for breaking crates with.
      LowAmmoWaterMark=0
      GoverningSkill=Class'DeusEx.SkillWeaponLowTech'
      NoiseLevel=0.050000

--- a/_Classes/DeusEx/Classes/WeaponCombatKnife.uc
+++ b/_Classes/DeusEx/Classes/WeaponCombatKnife.uc
@@ -90,7 +90,6 @@ exec function UpdateHDTPsettings()                                              
 
 defaultproperties
 {
-     bIsMeleeWeapon=True
      LowAmmoWaterMark=0
      GoverningSkill=Class'DeusEx.SkillWeaponLowTech'
      NoiseLevel=0.050000

--- a/_Classes/DeusEx/Classes/WeaponCrowbar.uc
+++ b/_Classes/DeusEx/Classes/WeaponCrowbar.uc
@@ -71,7 +71,6 @@ exec function UpdateHDTPsettings()                                              
 
 defaultproperties
 {
-     bIsMeleeWeapon=True
      LowAmmoWaterMark=0
      GoverningSkill=Class'DeusEx.SkillWeaponLowTech'
      NoiseLevel=0.050000

--- a/_Classes/DeusEx/Classes/WeaponNanoSword.uc
+++ b/_Classes/DeusEx/Classes/WeaponNanoSword.uc
@@ -133,7 +133,6 @@ state Active
 
 defaultproperties
 {
-     bIsMeleeWeapon=True
      LowAmmoWaterMark=0
      GoverningSkill=Class'DeusEx.SkillWeaponLowTech'
      reloadTime=0.000000

--- a/_Classes/DeusEx/Classes/WeaponSword.uc
+++ b/_Classes/DeusEx/Classes/WeaponSword.uc
@@ -101,7 +101,6 @@ function texture GetWeaponHandTex()                                             
 
 defaultproperties
 {
-     bIsMeleeWeapon=True
      LowAmmoWaterMark=0
      GoverningSkill=Class'DeusEx.SkillWeaponLowTech'
      NoiseLevel=0.050000


### PR DESCRIPTION
Instead of the last equipped melee weapon getting equipped when you left click an object, you pull up a melee weapon based on a priority list (sword, crowbar, combat knife, baton, DTS) and on non hardcore difficulties if the current priority doesn't deal enough damage to pass the object's DT it'll also skip to the next one in the priority list until it finds a weapon with enough DT or doesn't equip anything