### PR TITLE
Bug fixes by Trash: #1: The Bot That Eats Your Progress

### DIFF
--- a/_Classes/DeusEx/Classes/DeusExWeapon.uc
+++ b/_Classes/DeusEx/Classes/DeusExWeapon.uc
@@ -51,7 +51,7 @@ enum ELockMode
 };
 
 var bool				bReadyToFire;			// true if our bullets are loaded, etc.
-var() int				LowAmmoWaterMark;		// critical low ammo count
+var() travel int				LowAmmoWaterMark;		// critical low ammo count
 var travel int			ClipCount;				// number of bullets remaining in current clip
 var travel int			ARClipSize;
 var travel int			ARLoaded;

--- a/_Classes/DeusEx/Classes/SecurityBot4.uc
+++ b/_Classes/DeusEx/Classes/SecurityBot4.uc
@@ -37,8 +37,10 @@ function DifficultyMod(float CombatDifficulty, bool bHardCoreMode, bool bExtraHa
                 bReactLoudNoise = True;
                 CloakThreshold = 110;
                 if (bFirstLevelLoad || !bNotFirstDiffMod)                       //RSD: Only alter health if it's the first time loading the map
-                Health = 200;
-                EMPHitPoints = 120;
+                {
+                    Health = 200;
+                    EMPHitPoints = 120;
+                }
              }
              bNotFirstDiffMod = true;
 }


### PR DESCRIPTION
- (Hopefully) fixed an issue with security bot 4 resetting its EMPHitPoints on hardcore, causing it to not display the 'Disabled' text and removing all the player's effort damaging it with EMP if they loaded a save

- Fixed rifle's GL text changing from red to green on switching maps sometimes (LowAmmoWaterMark is now a travel value)