### PR TITLE
Accuracy Fix

### DIFF
--- a/Docs/List of Changes.md
+++ b/Docs/List of Changes.md
@@ -7,6 +7,7 @@ Sarge's Changes since Beta 2.2:
     - Fixed GMDX vRSD bug allowing using Tech Goggles in the secondary slot for half a second or so when out of charge
     - Fixed the Crosshair Visibility settings in the options getting constantly overridden by lasers etc. The outer crosshairs showing your accuracy are also now linked to the Crosshair visibility setting.
     - Fixed GMDX Bug where EMP'd turrets and cameras will re-enable themselves after the EMP effect runs out, even if they were disabled during the EMP effect.
+    - Fixed GMDX/Vanilla issue where you could retain your standing accuracy bonus after moving if you stood still for a long time. Now accuracy decreases immediately.
 - Quality of Life Improvements:
     - Lockpicks and Multitools will no longer be consumed if you look away from an object you're picking/bypassing. Instead, the action will be cancelled and any progress cancelled.
     - Added an optional "Dynamic Crosshair" mode, which shows a small dot-crosshair when no weapons is equipped, and some items have no crosshairs at all.

--- a/_Classes/DeusEx/Classes/DeusExWeapon.uc
+++ b/_Classes/DeusEx/Classes/DeusExWeapon.uc
@@ -299,6 +299,8 @@ var localized string abridgedName;                                              
 var texture largeIconRot;                                                       //RSD: rotated inventory icon
 var travel int invSlotsXtravel;                                                 //RSD: since Inventory invSlotsX doesn't travel through maps
 var travel int invSlotsYtravel;                                                 //RSD: since Inventory invSlotsY doesn't travel through maps
+var travel float previousAccuracy;                                                            //Sarge: Used to limit standing accuracy bonus from increasing past your max accuracy                                                                                
+
 //END GMDX:
 
 //
@@ -2394,6 +2396,7 @@ simulated function Tick(float deltaTime)
 	  SoundTimer = 0;
 	}
 
+    previousAccuracy = currentAccuracy;
 	currentAccuracy = CalculateAccuracy();
 
 	if (player != None)
@@ -2513,7 +2516,8 @@ simulated function Tick(float deltaTime)
 	        mult += 1.0;
         if (player.CombatDifficulty < 1.0)                                      //RSD: Properly doubling on easy now
 		    mult *= 2.0;
-        standingTimer += mult*deltaTime;
+        if (previousAccuracy != currentAccuracy || standingTimer ~= 0.0)                                       //Sarge: Only increase standing timer if our accuracy has changed
+            standingTimer += mult*deltaTime;
 		if (standingTimer > 15.0) //CyberP: the devs forgot to cap the timer
 		    standingTimer = 15.0;
         if (player.bHardcoreMode && IsInState('Reload'))                        //RSD: reset accuracy when reloading in Hardcore


### PR DESCRIPTION
The accuracy Standing Still bonus no longer continues to accrue after reaching max accuracy, which would allow you to maintain maximum accuracy for a long period after moving if you stood still for a long time.