### PR TITLE
Randomisation Changes

### DIFF
--- a/_Classes/DeusEx/Classes/DeusExPlayer.uc
+++ b/_Classes/DeusEx/Classes/DeusExPlayer.uc
@@ -543,6 +543,7 @@ var travel bool bRandomizeAugs;
 var travel bool bRandomizeEnemies;
 var travel bool bRestrictedSaving;												//Sarge: This used to be tied to hardcore, now it's a config option
 var travel bool bNoKeypadCheese;												//Sarge: Prevent using keycodes that we don't know
+var travel int seed;                                                            //Sarge: When using randomisation playthrough modifiers, this is our generated seed for the playthrough, to prevent autosave abuse and the like
 var travel int augOrderNums[21];                                                //RSD: New aug can order for scrambling
 var const augBinary augOrderList[21];                                           //RSD: List of all aug cans in the game in order (to be scrambled)
 var travel bool bAddictionSystem;
@@ -1115,7 +1116,13 @@ function SetupRandomizer()
     {
         //ClientMessage("Make new Randomiser");
 	    Randomizer = new(Self) class'RandomTable';
-        Randomizer.Generate();
+    }
+
+    //If no seed is set, generate a new one
+    if (seed == -1)
+    {
+        seed = Rand(10000);
+        //ClientMessage("Generating new playthrough seed: " $ seed);
     }
 }
 
@@ -16971,6 +16978,7 @@ function RegenStaminaTick(float deltaTime)                                      
 
 defaultproperties
 {
+     seed=-1;
      autosaveRestrictTimerDefault=900.0
      TruePlayerName="JC Denton"
      CombatDifficulty=1.000000

--- a/_Classes/DeusEx/Classes/MissionScript.uc
+++ b/_Classes/DeusEx/Classes/MissionScript.uc
@@ -97,7 +97,7 @@ function int GenerateMapSeed()
         seed += P.Location.Z;
     }
         
-    return int(seed) % 10000.00;
+    return abs(int(seed)) % 10000;
 }
 
 // ----------------------------------------------------------------------

--- a/_Classes/DeusEx/Classes/RandomTable.uc
+++ b/_Classes/DeusEx/Classes/RandomTable.uc
@@ -3,33 +3,45 @@
 //Used by the item randomisers.
 class RandomTable extends object;
 
-const MAX_VALUES = 500;
+// Linear Congruent RNG for 16-bit integers
+// parameters https://www.pcg-random.org/posts/visualizing-the-heart-of-some-prngs.html
+// Sarge: Provided by RSD. This is all greek to me
 
-var travel float values[500];
-var travel int index;
+const m_mod = 65536; //2^16
+const a_mult = 25385; //optimal primitive element of 2^16
+const c_inc = 1337; //any odd number
+                            
+var int internal_randval;
 
-function Generate()
+// Seed with integer between 0 and 2^32
+function Seed(int seed)
 {
-    local int i;
-    for (i=0;i<MAX_VALUES;i++)
-        values[i] = FRand();
+    internal_randval = abs(seed) % m_mod;
 }
 
-function int GetRandomInt(int multiply)
+function iterateRand()
 {
-    return int(values[GetIndex()] * multiply);
+    internal_randval = (a_mult*internal_randval + c_inc) % m_mod;
 }
 
-function int GetRandomFloat()
+function int GetRandomInt(int max)
 {
-    return values[GetIndex()];
+    local int randOut;
+
+    iterateRand();
+    //randOut = internal_randval % max; //RSD: biases the least significant bits for bad cycle period
+    randOut = (max*internal_randval)/m_mod;
+
+
+    return randOut;
 }
 
-function int GetIndex()
+function float GetRandomFloat()
 {
-    index++;
-    if (index >= MAX_VALUES)
-        index = 0;
+    local float randOut;
 
-    return index;
+	iterateRand();
+	randOut = float(internal_randval)/float(m_mod);
+	
+	return randOut;
 }


### PR DESCRIPTION
Previously, I tried to mitigate rerolling items by loading before a transition to a new map, by generating a table of random numbers ahead of time, rather than using the Rand() function on the items when the map is loaded.

This has some problems. Because the table of values had a single index, which was moved every time a new item was randomised, travelling to maps in a different order (such as going to the NYC Clinic before Smugglers, then reloading and going to Smugglers before the Clinic) would generate different outcomes.

Additionally, there's no guarantee that the randomisation was balanced, and potential problems involving repeating numbers as the index rolled over the end of the table (which contained 200 values).

Now, hopefully, all of these are fixed, thanks to a new Seed-based randomiser designed by RoSoDude.

The randomiser works like this:

1. The Player generates a seed using the standard rand() function at the start of their playthrough
2. Each map iterates all of it's PathNodes (chosen because they never move and aren't affected by gravity) and adds up their position X, Y and Z values, then modulo's the result by 10000. This forms a unique map signature, called the map seed.
3. These two seeds are added together to seed the randomiser.
4. Each object calls `GetRandomInt(int max)` or `GetRandomFloat()` on the Randomiser as it needs to, using the seeded values.

This should generate a statistically sound result, that is guaranteed to produce the same results for a given playthrough regardless of the order in which maps are visited.