### PR TITLE
Charged Item Belt Improvements

### DIFF
--- a/Docs/List of Changes.md
+++ b/Docs/List of Changes.md
@@ -8,6 +8,7 @@ Sarge's Changes since Beta 2.2:
     - Fixed the Crosshair Visibility settings in the options getting constantly overridden by lasers etc. The outer crosshairs showing your accuracy are also now linked to the Crosshair visibility setting.
     - Fixed GMDX Bug where EMP'd turrets and cameras will re-enable themselves after the EMP effect runs out, even if they were disabled during the EMP effect.
 - Quality of Life Improvements:
+    - In the Inventory screen, charged items will now show their charge level on their icon. Additionally, belt slots containing charged items will show their charge level.
     - Lockpicks and Multitools will no longer be consumed if you look away from an object you're picking/bypassing. Instead, the action will be cancelled and any progress cancelled.
     - Added an optional "Dynamic Crosshair" mode, which shows a small dot-crosshair when no weapons is equipped, and some items have no crosshairs at all.
         - Also fixed many instances of crosshair weirdness.

--- a/_Classes/DeusEx/Classes/ChargedPickup.uc
+++ b/_Classes/DeusEx/Classes/ChargedPickup.uc
@@ -14,6 +14,7 @@ var() sound LoopSound;
 var Texture ChargedIcon;
 var travel bool bIsActive;
 var localized String ChargeRemainingLabel;
+var localized String ChargeRemainingLabelSmall;
 var localized String DurabilityRemainingLabel;
 var localized String CanOnlyBeOne;
 var localized String PickupInfo1;
@@ -148,6 +149,7 @@ simulated function bool IsActive()
 
 function ChargedPickupUpdate(DeusExPlayer Player)
 {
+    UpdateBeltText(); //Sarge: Now we need to update the belt position because it shows charge amounts
 }
 
 // ----------------------------------------------------------------------
@@ -222,8 +224,8 @@ function UsedUp()
 	{
 		GotoState('DeActivated');                                               //RSD: Deactivate when the top one in the stack runs out (default)
 		//GotoState('Activated');                                                 //RSD: Automatically activate the next one in the stack
-		UpdateBeltText();
 		Charge=default.Charge;  //give back charge and make activatable
+		UpdateBeltText();
 		//if (Player != None)
 		//    Player.topCharge[x]=default.Charge;
 	}
@@ -497,6 +499,7 @@ defaultproperties
      ActivateSound=Sound'DeusExSounds.Pickup.PickupActivate'
      DeActivateSound=Sound'DeusExSounds.Pickup.PickupDeactivate'
      ChargeRemainingLabel="Charge remaining:"
+     ChargeRemainingLabelSmall="%d%%"
      DurabilityRemainingLabel="Durability:"
      CanOnlyBeOne="You cannot equip more than one torso armor piece"
      PickupInfo1="Environmental Protection: 60%"

--- a/_Classes/DeusEx/Classes/HUDObjectBelt.uc
+++ b/_Classes/DeusEx/Classes/HUDObjectBelt.uc
@@ -31,6 +31,16 @@ event InitWindow()
 	PopulateBelt();
 }
 
+// Set belt mode
+// Used for having different text on the inventory belt vs the HUD belt
+
+function SetInventoryBelt(bool option)
+{
+    local int i;
+	for (i=0; i<10; i++)
+        objects[i].bInventorySlot = option;
+}
+
 // ----------------------------------------------------------------------
 // CreateSlots()
 //

--- a/_Classes/DeusEx/Classes/HUDObjectSlot.uc
+++ b/_Classes/DeusEx/Classes/HUDObjectSlot.uc
@@ -24,6 +24,8 @@ var int			slotFillHeight;
 var int         borderWidth;
 var int         borderHeight;
 
+var bool        bInventorySlot;                       //Sarge: If true, this is the Inventory belt. If false it's the HUD belt
+
 // Stuff to optimize DrawWindow()
 var String      itemText;
 
@@ -153,6 +155,7 @@ function SetItem(Inventory newItem)
 function UpdateItemText()
 {
 	local DeusExWeapon weapon;
+	local ChargedPickup CP;
 
 	itemText = "";
 
@@ -171,6 +174,7 @@ function UpdateItemText()
 			if (weapon.IsA('WeaponNanoVirusGrenade') ||
 				weapon.IsA('WeaponGasGrenade') ||
 				weapon.IsA('WeaponEMPGrenade') ||
+				weapon.IsA('WeaponHideAGun')   || //Sarge: Added
 				weapon.IsA('WeaponLAM'))
 			{
 				if (weapon.AmmoType != none && weapon.AmmoType.AmmoAmount > 1)  //RSD: accessed none?
@@ -178,6 +182,20 @@ function UpdateItemText()
 			}
 
 		}
+        //Show ChargedPickup charge
+        else if (item.IsA('ChargedPickup'))
+        {
+            CP = ChargedPickup(item);
+            if (CP.GetCurrentCharge() > 0 && !bInventorySlot)
+                itemText = Sprintf(CP.ChargeRemainingLabelSmall,(int(CP.GetCurrentCharge())));
+			if (CP.NumCopies > 1)
+            {
+                if (itemtext == "")
+                    itemText = "x" @ CP.NumCopies;
+                else
+                    itemText = itemText @ "x" @ CP.NumCopies;
+            }
+        }
 		else if (item.IsA('DeusExPickup') && (!item.IsA('NanoKeyRing')))
 		{
 			// If the object is a SkilledTool (but not the NanoKeyRing) then show the
@@ -254,10 +272,13 @@ local DeusExWeapon weapon;
 			else if (weapon.AmmoName == class'Ammo20mmEMP' || weapon.AmmoName == class'AmmoPlasmaSuperheated' || weapon.AmmoName == class'AmmoSabot' || weapon.AmmoName == class'AmmoDartTaser')
 			gc.SetTextColor(colAmmoEMPText);
 			}
+        //Sarge: Disabled because it looks weird on the belt
+        /*
 		if (weapon != None && weapon.IsA('WeaponHideAGun') && weapon.ProjectileClass == class'DeusEx.PlasmaBolt')
-        gc.SetTextColor(colAmmoTranqText);
+            gc.SetTextColor(colAmmoTranqText);
         else if (weapon != None && weapon.IsA('WeaponHideAGun'))
         gc.SetTextColor(colAmmoEMPText);
+        */
 		}                                              //CyberP: end.
 
 		// If there's any additional text (say, for an ammo or weapon), draw it

--- a/_Classes/DeusEx/Classes/PersonaInventoryItemButton.uc
+++ b/_Classes/DeusEx/Classes/PersonaInventoryItemButton.uc
@@ -42,12 +42,14 @@ var Color colWeaponModFalse;
 var Color colDropGood;
 var Color colDropBad;
 var Color colNone;
+var Color colCharge;
 
 // Texture and Color for background
 var Color		fillColor;
 var Texture		fillTexture;
 
 var localized String CountLabel;
+var localized String ChargeLabel;
 var localized String RoundLabel;
 var localized String RoundsLabel;
 
@@ -60,7 +62,7 @@ var Color colIconDimmed; //RSD
 event DrawWindow(GC gc)
 {
 	local Inventory anItem;
-	local String str;
+	local String str,str2;
 	local DeusExWeapon weapon;
 	local float strWidth, strHeight;
 
@@ -136,33 +138,28 @@ event DrawWindow(GC gc)
 			{
 				str = weapon.AmmoType.beltDescription;
 			}
-
-			if (str != "")
-			{
-				gc.SetFont(Font'FontMenuSmall_DS');
-				gc.SetAlignments(HALIGN_Center, VALIGN_Center);
-				gc.SetTextColor(colHeaderText);
-				gc.GetTextExtent(0, strWidth, strHeight, str);
-				gc.DrawText(0, height - strHeight, width, strHeight, str);
-			}
 		}
 
 		// Check to see if we need to print "x copies"
 		if (anItem.IsA('DeusExPickup') && (!anItem.IsA('NanoKeyRing')))
 		{
-			if (DeusExPickup(anItem).NumCopies > 1)
-			{
+            if (DeusExPickup(anItem).NumCopies > 1)
 				str = Sprintf(CountLabel, DeusExPickup(anItem).NumCopies);
 
-				gc.SetFont(Font'FontMenuSmall_DS');
-				gc.SetAlignments(HALIGN_Center, VALIGN_Center);
-				gc.SetTextColor(colHeaderText);
-				gc.GetTextExtent(0, strWidth, strHeight, str);
-				gc.DrawText(0, height - strHeight, width, strHeight, str);
-			}
+            //SARGE: Add charge for ChargedItems
+            if (anItem.isA('ChargedPickup') && ChargedPickup(anItem).GetCurrentCharge() > 0)
+                str2 = Sprintf("%d%%", int(ChargedPickup(anItem).GetCurrentCharge()));
 		}
 		}
 	}
+
+    gc.SetFont(Font'FontMenuSmall_DS');
+    gc.SetAlignments(HALIGN_Center, VALIGN_Center);
+    gc.SetTextColor(colHeaderText);
+    gc.GetTextExtent(0, strWidth, strHeight, "      ");
+    gc.DrawText(0, height - strHeight, width, strHeight, str);
+    //gc.SetTextColor(colCharge);
+    gc.DrawText(0, height/2 - strHeight/2, width, strHeight, str2);
 
 	// Draw selection border width/height of button
 	if (bSelected)
@@ -568,8 +565,10 @@ defaultproperties
      colDropBad=(R=128,G=32,B=32)
      fillTexture=Texture'Extension.Solid'
      CountLabel="Count: %d"
+     ChargeLabel="Charge: %d%%"
      RoundLabel="%d Rd"
      RoundsLabel="%d Rds"
      colDropSwap=(R=16,G=32,B=128)
      colIconDimmed=(R=64,G=64,B=64)
+     colCharge=(R=255,G=243,B=109)
 }

--- a/_Classes/DeusEx/Classes/PersonaInventoryObjectBelt.uc
+++ b/_Classes/DeusEx/Classes/PersonaInventoryObjectBelt.uc
@@ -27,6 +27,7 @@ event InitWindow()
 	// Create our local object belt, then get a pointer to the HUD belt
 	objBelt = HUDObjectBelt(NewChild(Class'HUDObjectBelt'));
 	objBelt.SetPos(90, 0);
+    objBelt.SetInventoryBelt(true);
 	objBelt.SetVisibility(True);
 	objBelt.SetInteractive(True);
 


### PR DESCRIPTION
* Charged Items now show their Charge% on the belt
* Charged Items now show their Charge% in the inventory screen
* The PS20 has also been given an ammo count on the belt.

Inventory Charge can be seen here:
![image](https://github.com/tunbridgep/gmdx-vrsd-fork/assets/31608726/092fa17b-5089-4163-af5e-f550902048ef)

Belt Charge:
![image](https://github.com/tunbridgep/gmdx-vrsd-fork/assets/31608726/527e5083-cc80-4ae2-9e74-b8822803b724)
