### PR TITLE
Throwing Knife Rebalance

### DIFF
--- a/_Classes/DeusEx/Classes/DeusExPlayer.uc
+++ b/_Classes/DeusEx/Classes/DeusExPlayer.uc
@@ -10408,7 +10408,7 @@ function bool GetCrosshairState(optional bool bCheckForOuterCrosshairs)
         //Accuracy Crosshair stuff
         if (bCheckForOuterCrosshairs)
         {
-            if (W.bHandToHand || W.IsA('WeaponShuriken') || W.GoverningSkill == class'DeusEx.SkillDemolition') //Melee weapons and grenades have no accuracy crosshairs
+            if (!W.isA('WeaponShuriken') && (W.bHandToHand || W.GoverningSkill == class'DeusEx.SkillDemolition')) //Melee weapons and grenades have no accuracy crosshairs
                 return false;
             else if (bHardcoreMode && W.IsInState('Reload')) //RSD: Remove the accuracy indicators if reloading on Hardcore
                 return false;

--- a/_Classes/DeusEx/Classes/DeusExProjectile.uc
+++ b/_Classes/DeusEx/Classes/DeusExProjectile.uc
@@ -914,6 +914,10 @@ local DeusExPlayer player;                                                      
 					if (bPlusOneDamage)                                         //RSD: remove random damage variation
 						Damage=Damage-1.0;
 					Wall.TakeDamage(Damage, Pawn(Owner), Wall.Location, MomentumTransfer*Normal(Velocity), damageType);
+                    
+                    //Sarge: Don't allow knives to be retrieved if they damaged a locked object
+                    if (IsA('Shuriken') && DeusExMover(Wall).bLocked && Damage >= DeusExMover(Wall).minDamagethreshold)
+                        Destroy();
 				}
 			}
 		}

--- a/_Classes/DeusEx/Classes/Shuriken.uc
+++ b/_Classes/DeusEx/Classes/Shuriken.uc
@@ -63,48 +63,49 @@ simulated function PreBeginPlay()
 simulated function PostBeginPlay()
 {
     local DeusExPlayer player;
-
-   if (Owner != None)
-   {
-     if (Owner.IsA('ScriptedPawn'))
-     {
-     speed=1300.000000;
-     MaxSpeed=1300.000000;
-     }
-     /*else if (Owner.IsA('DeusExPlayer') && DeusExPlayer(Owner).SkillSystem.GetSkillLevel(class'SkillWeaponLowTech') >= 2)
-     {
-     Velocity*=3;
-     speed=3000.000000;
-     MaxSpeed=3000.000000;
-     }
-     else
-     {
-     Velocity*=1.5;
-     speed=1800.000000;
-     MaxSpeed=1800.000000;
-     }*/
-   }
-Super.PostBeginPlay();
+    local int skillLevel;
 
     player = DeusExPlayer(Owner);
+
+    if (Owner != None)
+    {
+        if (Owner.IsA('ScriptedPawn'))
+        {
+        speed=1300.000000;
+        MaxSpeed=1300.000000;
+        }
+        //Sarge: If we are a player, throw the knives faster as our skill increases
+        else if (player != None)
+        {
+            skillLevel = player.SkillSystem.GetSkillLevel(class'SkillWeaponLowTech');
+            if (skillLevel > 0)
+            {
+                Velocity*=skillLevel;
+                speed += 300 * skillLevel;
+                MaxSpeed += 300 * skillLevel;
+            }
+        }
+    }
+
+    Super.PostBeginPlay();
 
     PlaySound(sound'CombatKnifeFire',SLOT_None,,,,1.5);
 
     if (player != None && player.PerkNamesArray[4]==1)
     {
-     smokeGen = Spawn(class'ParticleGenerator', Self);
-	if (smokeGen != None)
-	{
-	  smokeGen.RemoteRole = ROLE_None;
-		smokeGen.particleTexture = Texture'DeusExItems.Skins.FlatFXTex46';
-		smokeGen.particleDrawScale = 0.08;
-		smokeGen.checkTime = 0.05;
-		smokeGen.riseRate = 0.0;
-		smokeGen.ejectSpeed = 0.0;
-		smokeGen.particleLifeSpan = 0.5;
-		smokeGen.bRandomEject = False;
-		smokeGen.SetBase(Self);
-	}
+        smokeGen = Spawn(class'ParticleGenerator', Self);
+        if (smokeGen != None)
+        {
+            smokeGen.RemoteRole = ROLE_None;
+            smokeGen.particleTexture = Texture'DeusExItems.Skins.FlatFXTex46';
+            smokeGen.particleDrawScale = 0.08;
+            smokeGen.checkTime = 0.05;
+            smokeGen.riseRate = 0.0;
+            smokeGen.ejectSpeed = 0.0;
+            smokeGen.particleLifeSpan = 0.5;
+            smokeGen.bRandomEject = False;
+            smokeGen.SetBase(Self);
+        }
 	}
 }
 

--- a/_Classes/DeusEx/Classes/WeaponShuriken.uc
+++ b/_Classes/DeusEx/Classes/WeaponShuriken.uc
@@ -32,7 +32,7 @@ defaultproperties
 {
      LowAmmoWaterMark=5
      GoverningSkill=Class'DeusEx.SkillWeaponLowTech'
-     NoiseLevel=0.050000
+     NoiseLevel=0.010000
      EnemyEffective=ENMEFF_Organic
      EnviroEffective=ENVEFF_AirVacuum
      Concealability=CONC_Visual


### PR DESCRIPTION
- Throwing Knives can no longer damage locked objects without breaking.
- Throwing Speed is now faster depending on weapon skill. This has a tangible effect on projectile drop, and should make them much easier to use at higher skill levels.
- Noise Level reduced from 0.05 to 0.01. This probably doesn't make a tangible difference to gameplay.