### PR TITLE
Added a "No Console Allowed" playthrough modifier.

### DIFF
--- a/Docs/List of Changes.md
+++ b/Docs/List of Changes.md
@@ -123,6 +123,7 @@ Sarge's Changes since Beta 2.2:
     - Increased the sawed off shotgun's pellet count from 8 to 9, and decreased shot speed from 1.3 to 1.2.
     - Rubber shells are now hitscan with a harmless projectile.
     - Restricted Saving is now a Playthrough Modifier and is no longer restricted to Hardcore Mode. It's still enforced in Hardcore Mode.
+    - Added No Console Access Playthrough Modifier, which prevents using the console (disallows cheats) while playing.
     - Added No Keypad Cheese Playthrough Modifier (called "Unknown Codes") which prevents using keypads or computer logins without having found them beforehand. Some codes which are hinted but never given are excepted.
     - AI Behaviour Changes
         - Enemies will now have a small delay (usually between 0.1 and 0.6) seconds before firing after losing sight of the player.

--- a/_Classes/DeusEx/Classes/DeusExPlayer.uc
+++ b/_Classes/DeusEx/Classes/DeusExPlayer.uc
@@ -564,6 +564,11 @@ var bool bNanoVirusSentMessage;                                                 
 var localized String NanoVirusLabel;                                            //RSD: For deactivating augs from scrambler grenades
 var globalconfig bool bRestrictedMetabolism;                                    //RSD: Enables restricted eating and halved withdrawal delay
 
+//SARGE: Allow blocking the next weapon selection. Used by dialog number keys feature
+var bBlockNextBeltSelection;
+
+//GAMEPLAY MODIFIERS
+
 /*var travel bool bRandomizeCratesGeneralTool;
 var travel bool bRandomizeCratesGeneralWearable;
 var travel bool bRandomizeCratesGeneralPickup;
@@ -588,15 +593,22 @@ var travel int seed;                                                            
 var travel int augOrderNums[21];                                                //RSD: New aug can order for scrambling
 var const augBinary augOrderList[21];                                           //RSD: List of all aug cans in the game in order (to be scrambled)
 var travel bool bAddictionSystem;
-var travel AddictionSystem AddictionManager;
-var travel PerkSystem PerkManager;
-var travel RandomTable Randomizer;
 
+var travel bool bMoreLDDPNPCs;
+
+var travel bool bDisableConsoleAccess;                                          //SARGE: Disable console access via a modifier.
+
+//END GAMEPLAY MODIFIERS
+
+//Autosave Stuff
 var travel float autosaveRestrictTimer;                                         //Sarge: Current time left before we're allowed to autosave again.
 var const float autosaveRestrictTimerDefault;                                   //Sarge: Timer for autosaves.
 var travel bool bResetAutosaveTimer;                                            //Sarge: This is necessary because our timer isn't set properly during the same frame as saving, for some reason.
 
-var travel bool bMoreLDDPNPCs;
+
+var travel AddictionSystem AddictionManager;
+var travel PerkSystem PerkManager;
+var travel RandomTable Randomizer;
 
 const DRUG_TOBACCO = 0;
 const DRUG_ALCOHOL = 1;
@@ -1584,21 +1596,27 @@ function string retInfo()
 //GMDX remove console from Hardcore mode >:]
 exec function Say(string Msg )
 {
-	//if (bHardCoreMode) return; else                                           //RSD: temporarily re-enable console for HC testing
-	  super.Say(Msg);
+	if (bDisableConsoleAccess || bExtraHardcore)
+        return;
+    else                                                                  //RSD: temporarily re-enable console for HC testing //SARGE: Made it a gameplay modifier
+	    super.Say(Msg);
 }
 
+//SARGE: TODO: Add a proper console window.
 exec function Type()
 {
-	//if (bHardCoreMode) return; else                                           //RSD: temporarily re-enable console for HC testing
+	if (bDisableConsoleAccess || bExtraHardcore)                         //RSD: temporarily re-enable console for HC testing //SARGE: Made it a gameplay modifier
+        return;
+    else
 	  super.Type();
 }
 
 function Typing( bool bTyping )
 {
-	/*if (bHardCoreMode)                                                        //RSD: temporarily re-enable console for HC testing
-	  Player.Console.GotoState('');
-	else*/ super.Typing(bTyping);
+	if (bDisableConsoleAccess || bExtraHardcore)                                                        //RSD: temporarily re-enable console for HC testing //SARGE: Made it a gameplay modifier
+	    Player.Console.GotoState('');
+	else
+        super.Typing(bTyping);
 }
 
 /////

--- a/_Classes/DeusEx/Classes/MenuScreenNewGame.uc
+++ b/_Classes/DeusEx/Classes/MenuScreenNewGame.uc
@@ -73,8 +73,9 @@ var bool bRestrictedSaving;
 var bool bNoKeypadCheese;
 var bool bExtraHardcore;
 var bool bMoreLDDPNPCs;
-var bool bRestrictedMetabolism;
+//var bool bRestrictedMetabolism;
 var bool bPrisonStart;
+var bool bDisableConsoleAccess;
 
 //LDDP
 var bool bFemaleEnabled;
@@ -133,7 +134,8 @@ event InitWindow()
     bRandomizeEnemies=false;                                                    //Sarge
     bExtraHardcore=false;                                                       //Sarge
     bMoreLDDPNPCs=false;                                                        //Sarge
-    //bRestrictedMetabolism=false;                                                //Sarge
+    bDisableConsoleAccess=false;                                                //Sarge
+    //bRestrictedMetabolism=false;                                              //Sarge
     default.bRandomizeCrates=false;                                             //RSD: Also need default values! Otherwise get command in modifier menu takes the wrong value
     default.bRandomizeMods=false;                                               //RSD
     default.bRandomizeAugs=false;                                               //RSD
@@ -145,6 +147,7 @@ event InitWindow()
     default.bMoreLDDPNPCs=false;                                                //Sarge
     //default.bRestrictedMetabolism=false;                                      //Sarge
     default.bPrisonStart=false;                                                 //Sarge
+    default.bDisableConsoleAccess=false;                                        //Sarge
 
 	StyleChanged();
 }
@@ -793,7 +796,8 @@ function SaveSettings()
     player.bAddictionSystem=bAddictionSystem;
     player.bExtraHardcore=bExtraHardcore;
     //player.bRestrictedMetabolism=bRestrictedMetabolism;
-    player.bMoreLDDPNPCs=bMoreLDDPNPCs;
+    player.bMoreLDDPNPCs=bMoreLDDPNPCs;                                         //Sarge
+    player.bDisableConsoleAccess=bDisableConsoleAccess;                         //Sarge
 
     //LDDP
 	THuman = Human(Player);

--- a/_Classes/DeusEx/Classes/MenuScreenPlaythroughModifiers.uc
+++ b/_Classes/DeusEx/Classes/MenuScreenPlaythroughModifiers.uc
@@ -49,7 +49,8 @@ defaultproperties
      items(6)=(HelpText="Prevents manually saving and adds single-use save points to the level. Autosaves still occur as normal. Always enabled in Hardcore mode.",actionText="Restricted Saving",variable="bRestrictedSaving");
      items(7)=(HelpText="Prevents using keypads and logins unless you have them in your notes.",actionText="Undiscovered Codes",variable="bNoKeypadCheese");
      items(8)=(HelpText="Start the game in the MJ12 Prison facility. Not recommended for new players! Also skips the intro cutscene.",actionText="Alternate Start",variable="bPrisonStart");
-     items(9)=(HelpText="Enable additional NPC's added by the Lay-D Denton mod. By default only the most relevant ones are enabled.",actionText="Add extra Lay-D Denton NPCs",variable="bMoreLDDPNPCs");
+     items(9)=(HelpText="Disable the use of the console.",actionText="Disable Console Access",variable="bDisableConsoleAccess");
+     items(10)=(HelpText="Enable additional NPC's added by the Lay-D Denton mod. By default only the most relevant ones are enabled.",actionText="Add extra Lay-D Denton NPCs",variable="bMoreLDDPNPCs");
      Title="Playthrough Modifiers"
      consoleTarget="MenuScreenNewGame"
 }


### PR DESCRIPTION
Hardcore used to do this automatically in RSD, until it was "temporarily" disabled. Now it's back.

TODO: Make this always enabled on Hardcore.
TODO: Documentation.