### PR TITLE
Heart Fixes

### DIFF
--- a/_Classes/DeusEx/Classes/Augmentation.uc
+++ b/_Classes/DeusEx/Classes/Augmentation.uc
@@ -18,6 +18,8 @@ var travel int HotKeyNum;
 var travel Augmentation next;
 var bool bUsingMedbot;
 
+var bool bHeartUpgraded;    //SARGE: Stores if an aug was upgraded via heart. Used for downgrading if we remove heart.
+
 var localized String EnergyRateLabel;
 var localized string OccupiesSlotLabel;
 var localized string AugLocsText[7];

--- a/_Classes/DeusEx/Classes/PersonaAugmentationItemButton.uc
+++ b/_Classes/DeusEx/Classes/PersonaAugmentationItemButton.uc
@@ -81,6 +81,17 @@ function SetLevel(int newLevel)
 }
 
 // ----------------------------------------------------------------------
+// SetHeartUpgraded()
+// SARGE: Set red icons when upgraded by heart.
+// ----------------------------------------------------------------------
+
+function SetHeartUpgraded(bool heart)
+{
+	if (winLevels != None)
+		winLevels.SetHeart(heart);
+}
+
+// ----------------------------------------------------------------------
 // ----------------------------------------------------------------------
 
 defaultproperties

--- a/_Classes/DeusEx/Classes/PersonaLevelIconWindow.uc
+++ b/_Classes/DeusEx/Classes/PersonaLevelIconWindow.uc
@@ -7,9 +7,12 @@ class PersonaLevelIconWindow extends PersonaBaseWindow;
 var int     currentLevel;
 var Texture texLevel;
 var Bool    bSelected;
+var Bool    bHeart;
 
 var int iconSizeX;
 var int iconSizeY;
+
+var Color colHeart;
 
 // ----------------------------------------------------------------------
 // InitWindow()
@@ -35,6 +38,16 @@ function SetSelected(bool bNewSelected)
 }
 
 // ----------------------------------------------------------------------
+// SetHeart()
+// ----------------------------------------------------------------------
+
+function SetHeart(bool bNewHeart)
+{
+	bHeart = bNewHeart;
+	StyleChanged();
+}
+
+// ----------------------------------------------------------------------
 // DrawWindow()
 // ----------------------------------------------------------------------
 
@@ -47,6 +60,9 @@ event DrawWindow(GC gc)
 
 	for(levelCount=0; levelCount<=currentLevel; levelCount++)
 	{
+        if (levelCount == currentLevel && bHeart)
+            gc.SetTileColor(colHeart);
+
 		gc.DrawTexture(levelCount * (iconSizeX + 1), 0, iconSizeX, iconSizeY,
 			0, 0, texLevel);
 	}
@@ -75,6 +91,8 @@ event StyleChanged()
 		colText = theme.GetColorFromName('HUDColor_ButtonTextFocus');
 	else
 		colText = theme.GetColorFromName('HUDColor_ButtonTextNormal');
+
+    colHeart = theme.GetColorFromName('HUDColor_ButtonTextDisabled');
 }
 
 // ----------------------------------------------------------------------

--- a/_Classes/DeusEx/Classes/PersonaScreenAugmentations.uc
+++ b/_Classes/DeusEx/Classes/PersonaScreenAugmentations.uc
@@ -693,6 +693,7 @@ function RefreshWindow(float DeltaTime)
     if (selectedAugButton != None)
     {
         PersonaAugmentationItemButton(selectedAugButton).SetLevel(selectedAug.GetCurrentLevel());
+        PersonaAugmentationItemButton(selectedAugButton).SetHeartUpgraded(selectedAug.bHeartUpgraded);
         PersonaAugmentationItemButton(selectedAugButton).SetActive(selectedAug);
     }
 
@@ -846,6 +847,7 @@ function PersonaAugmentationItemButton CreateAugButton(Augmentation anAug, int a
     }
 
 	newButton.SetLevel(anAug.GetCurrentLevel());
+    newButton.SetHeartUpgraded(anAug.bHeartUpgraded);
 
 	return newButton;
 }
@@ -1160,7 +1162,10 @@ function UpgradeAugmentation()
         }
 		// Update the level icons
 		if (selectedAugButton != None)
+        {
 			PersonaAugmentationItemButton(selectedAugButton).SetLevel(selectedAug.GetCurrentLevel());
+			PersonaAugmentationItemButton(selectedAugButton).SetHeartUpgraded(selectedAug.bHeartUpgraded);
+        }
 	}
 	else if (augCan != None)
 	{
@@ -1175,7 +1180,10 @@ function UpgradeAugmentation()
 
 		// Update the level icons
 		if (selectedAugButton != None)
+        {
 			PersonaAugmentationItemButton(selectedAugButton).SetLevel(selectedAug.GetCurrentLevel());
+			PersonaAugmentationItemButton(selectedAugButton).SetHeartUpgraded(selectedAug.bHeartUpgraded);
+        }
 
 	}
 


### PR DESCRIPTION
Heart is now tracked properly, so removing it removes all aug levels that were upgraded via heart, and doesn't remove those that were upgraded via upgrade cans.