### PR TITLE
Belt Consistency

### DIFF
--- a/_Classes/DeusEx/Classes/HUDObjectBelt.uc
+++ b/_Classes/DeusEx/Classes/HUDObjectBelt.uc
@@ -314,7 +314,7 @@ function RefreshAlternateToolbelt()
                 objects[slotIndex].SetToggle(player.inHandPending != None && slotIndex == player.inHandPending.beltPos);
                 
                 //White outline stays with our current weapon
-                objects[slotIndex].HighlightSelect(slotIndex == player.advBelt && !placeholderSlot && objects[slotIndex].item != None);
+                objects[slotIndex].HighlightSelect(slotIndex == player.advBelt && !placeholderSlot && objects[slotIndex].item != None && !player.bSelectedOffBelt);
             }
             else
             {
@@ -322,7 +322,7 @@ function RefreshAlternateToolbelt()
                 objects[slotIndex].HighlightSelect(player.inHandPending != None && slotIndex == player.inHandPending.beltPos);
                 
                 //White outline stays with our primary selection
-                objects[slotIndex].SetToggle(slotIndex == player.advBelt && !placeholderSlot && objects[slotIndex].item != None);
+                objects[slotIndex].SetToggle(slotIndex == player.advBelt && !placeholderSlot && objects[slotIndex].item != None && !player.bSelectedOffBelt);
             }
 		}
 	}


### PR DESCRIPTION
Unholstering now always selects the last selected belt item, rather than your true last weapon. This makes using the "standard" toolbelt far more consistent. Off-belt selection can now always be respected using the bAllowOffBeltSelection setting, but it feels weird so it's disabled by default. No menu option.

IW Belt and standard Belt should now act a little more alike, in a good way.