### PR TITLE
Augmentation 'Install' button fix

### DIFF
--- a/_Classes/DeusEx/Classes/HUDMedBotAddAugsScreen.uc
+++ b/_Classes/DeusEx/Classes/HUDMedBotAddAugsScreen.uc
@@ -111,11 +111,12 @@ function CreateButtons()
 	winActionButtons.SetWidth(96);
 
 	btnInstall = PersonaActionButtonWindow(winActionButtons.NewChild(Class'PersonaActionButtonWindow'));
+	btnInstall.bCenterText = false;
 	btnInstall.SetButtonText(InstallButtonLabel);
 
 	chkAutoswitch = PersonaCheckboxWindow(winClient.NewChild(Class'PersonaCheckboxWindow'));
 	chkAutoswitch.SetText(AutoswitchText);
-	chkAutoswitch.SetPos(346+96+4, 371);
+	chkAutoswitch.SetPos(346+96+4, 373);
 	chkAutoswitch.SetWidth(200);
     chkAutoswitch.SetToggle(player.bMedbotAutoswitch);
 }


### PR DESCRIPTION
- Reset the button centered text to the left.
- Lower the position of the check box line to be aligned with the button text.