### PR TITLE
WP Rockets now do 25% damage against movers, to discourage using them to doorbust.

### DIFF
--- a/Docs/List of Changes.md
+++ b/Docs/List of Changes.md
@@ -267,6 +267,7 @@ Sarge's Changes since Beta 2.2:
     - Putting a scope or a laser sight on the GEP gun now requires the Heavily Tweaked perk (ADVANCED heavy weapons, 100 skill points). The scope and laser sight still provide rocket guidance capabilities.
     - Added a new "Killswitch Engaged" Playthrough Modifier. When enabled, all augmentations will be disabled and a countdown timer will be active while your killswitch is enabled.
     - Added a new "Weapon Requirements Matter" Playthrough Modifier. When enabled, most weapons will require a minimum skill investment in order to be used.
+    - WP Rockets now only deal 25% damage against movers, to make blowing everything up a little harder and solidify their role as anti-personal rockets.
     - Demolitions Skill Overhaul:
         - Demolitions Skill-based grenade timing rescaled from 0.5, 1.0, 2.5, 7.0 seconds to 0.75, 1.0, 1.5, 2.5 seconds
         - Being able to pick up disarmed grenades is now based on skill level - Trained for Gas Grenades, Advanced for EMP and Scrambler Grenades, Master for LAMs.

--- a/System/DeusEx.int
+++ b/System/DeusEx.int
@@ -2285,7 +2285,7 @@ beltDescription="20MM AMMO"
 
 [AmmoRocketWP]
 ItemName="WP Rockets"
-Description="The white-phosphorus rocket, or 'wooly peter,' was designed to expand the mission profile of the GEP gun. While it does minimal damage upon detonation, the explosion will spread a cloud of particularized white phosphorus that ignites immediately upon contact with the air."
+Description="The white-phosphorus rocket, or 'wooly peter,' was designed to expand the mission profile of the GEP gun. While it does minimal damage upon detonation, the explosion will spread a cloud of particularized white phosphorus that ignites immediately upon contact with the air.|n|n<UNATCO OPS FILE NOTE JR337-INDIGO>WP Rockets are made of a frangible substance and do not pack the direct-fire stopping power of a regular rocket, and should not be used for breaching doors or other structures. In these cases, it's better to use a regular rocket instead -- Sam Carter <END NOTE>"
 beltDescription="WP ROCKET"
 
 [AugHealing]

--- a/_Classes/DeusEx/Classes/DeusExMover.uc
+++ b/_Classes/DeusEx/Classes/DeusExMover.uc
@@ -509,6 +509,10 @@ function TakeDamage(int Damage, Pawn instigatedBy, Vector hitlocation, Vector mo
 
 	if ((DamageType == 'EMP') || (DamageType == 'NanoVirus') || (DamageType == 'Shocked'))
 		return;
+   
+    //SARGE: 25% damage from WP rockets
+    if ((DamageType == 'Flamed'))
+       damage *= 0.25;
 
     if (InstigatedBy != none && InstigatedBy.Weapon != none && InstigatedBy.Weapon.IsA('WeaponCrowbar')) //RSD: New special effect for the crowbar: additional 5 damage vs inanimate objects //SARGE: Now 2x
        damage *= 2;

--- a/_Classes/DeusEx/Classes/DeusExWeapon.uc
+++ b/_Classes/DeusEx/Classes/DeusExWeapon.uc
@@ -1644,7 +1644,10 @@ function int CalculateTrueDamage()
 
     trueDamage = int(hit * (1.0 - (2.0 * GetWeaponSkill()) + mult + ModDamage));
 
-    //P.ClientMessage("Damage: " $ hit $ " - " $ trueDamage @ "(" $ mult @ GetWeaponSkill() @ ")");
+    if (ammoType != None && ammoType.Class == class'AmmoRocketWP')
+        trueDamage *= 0.25 * 0.25;
+
+    //P.ClientMessage("Damage: " $ hit $ " - " $ trueDamage @ "(" $ mult @ GetWeaponSkill() @ ")" $ ", AmmoType is " $ ammoType.Class);
 	return trueDamage;
 }
 


### PR DESCRIPTION
Ammo Description and FROB display also updated to reflect the change.